### PR TITLE
Updated is_comment logic

### DIFF
--- a/kikar_hamedina/facebook_feeds/admin.py
+++ b/kikar_hamedina/facebook_feeds/admin.py
@@ -4,7 +4,7 @@ from models import Facebook_Feed, \
     Facebook_Status, \
     Tag as OldTag, \
     User_Token, Feed_Popularity, Facebook_Persona, \
-    Facebook_Status_Attachment
+    Facebook_Status_Attachment, Status_Comment_Pattern
 
 
 admin.site.register(Facebook_Feed)
@@ -13,3 +13,4 @@ admin.site.register(OldTag)
 admin.site.register(User_Token)
 admin.site.register(Feed_Popularity)
 admin.site.register(Facebook_Status_Attachment)
+admin.site.register(Status_Comment_Pattern)

--- a/kikar_hamedina/facebook_feeds/fixtures/data_fixture_facebook_feeds.json
+++ b/kikar_hamedina/facebook_feeds/fixtures/data_fixture_facebook_feeds.json
@@ -2547,5 +2547,33 @@
             "name": "\u05d4\u05e1\u05e4\u05d3", 
             "statuses": ""
         }
+    },
+    {
+        "pk": 1,
+        "model": "facebook_feeds.status_comment_pattern",
+        "fields": {
+            "pattern": "{name} likes"
+        }
+    },
+    {
+        "pk": 2,
+        "model": "facebook_feeds.status_comment_pattern",
+        "fields": {
+            "pattern": "{name} liked"
+        }
+    },
+    {
+        "pk": 3,
+        "model": "facebook_feeds.status_comment_pattern",
+        "fields": {
+            "pattern": "{name} commented"
+        }
+    },
+    {
+        "pk": 4,
+        "model": "facebook_feeds.status_comment_pattern",
+        "fields": {
+            "pattern": "{name} replied"
+        }
     }
 ]

--- a/kikar_hamedina/facebook_feeds/migrations/0019_auto__add_status_comment_pattern.py
+++ b/kikar_hamedina/facebook_feeds/migrations/0019_auto__add_status_comment_pattern.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'Status_Comment_Pattern'
+        db.create_table(u'facebook_feeds_status_comment_pattern', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('pattern', self.gf('django.db.models.fields.CharField')(max_length=128)),
+        ))
+        db.send_create_signal(u'facebook_feeds', ['Status_Comment_Pattern'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'Status_Comment_Pattern'
+        db.delete_table(u'facebook_feeds_status_comment_pattern')
+
+
+    models = {
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'facebook_feeds.facebook_feed': {
+            'Meta': {'ordering': "['feed_type']", 'object_name': 'Facebook_Feed'},
+            'about': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'}),
+            'birthday': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'current_fan_count': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'feed_type': ('django.db.models.fields.CharField', [], {'default': "'PP'", 'max_length': '2'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_current': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'link': ('django.db.models.fields.URLField', [], {'max_length': '2000', 'null': 'True', 'blank': 'True'}),
+            'locally_updated': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(1970, 1, 1, 0, 0)', 'blank': 'True'}),
+            'name': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'persona': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'feeds'", 'to': u"orm['facebook_feeds.Facebook_Persona']"}),
+            'picture_large': ('django.db.models.fields.URLField', [], {'max_length': '2000', 'null': 'True', 'blank': 'True'}),
+            'picture_square': ('django.db.models.fields.URLField', [], {'max_length': '2000', 'null': 'True', 'blank': 'True'}),
+            'requires_user_token': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'username': ('django.db.models.fields.TextField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'vendor_id': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'website': ('django.db.models.fields.URLField', [], {'max_length': '2000', 'null': 'True', 'blank': 'True'})
+        },
+        u'facebook_feeds.facebook_persona': {
+            'Meta': {'object_name': 'Facebook_Persona'},
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'main_feed': ('django.db.models.fields.SmallIntegerField', [], {'default': '0', 'null': 'True', 'blank': 'True'}),
+            'object_id': ('django.db.models.fields.PositiveIntegerField', [], {})
+        },
+        u'facebook_feeds.facebook_status': {
+            'Meta': {'object_name': 'Facebook_Status'},
+            'comment_count': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'blank': 'True'}),
+            'content': ('django.db.models.fields.TextField', [], {}),
+            'feed': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['facebook_feeds.Facebook_Feed']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_comment': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'like_count': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'blank': 'True'}),
+            'locally_updated': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(1970, 1, 1, 0, 0)', 'blank': 'True'}),
+            'published': ('django.db.models.fields.DateTimeField', [], {}),
+            'share_count': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'blank': 'True'}),
+            'status_id': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '128'}),
+            'status_type': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '128', 'null': 'True', 'blank': 'True'}),
+            'story': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'story_tags': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {})
+        },
+        u'facebook_feeds.facebook_status_attachment': {
+            'Meta': {'object_name': 'Facebook_Status_Attachment'},
+            'caption': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'facebook_object_id': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'link': ('django.db.models.fields.TextField', [], {}),
+            'name': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'picture': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'status': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'attachment'", 'unique': 'True', 'to': u"orm['facebook_feeds.Facebook_Status']"}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '16', 'null': 'True', 'blank': 'True'})
+        },
+        u'facebook_feeds.feed_popularity': {
+            'Meta': {'ordering': "['-date_of_creation']", 'object_name': 'Feed_Popularity'},
+            'date_of_creation': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2014, 11, 24, 0, 0)'}),
+            'fan_count': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'feed': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['facebook_feeds.Facebook_Feed']"}),
+            'followers_count': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'friends_count': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'talking_about_count': ('django.db.models.fields.IntegerField', [], {'default': '0'})
+        },
+        u'facebook_feeds.status_comment_pattern': {
+            'Meta': {'object_name': 'Status_Comment_Pattern'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'pattern': ('django.db.models.fields.CharField', [], {'max_length': '128'})
+        },
+        u'facebook_feeds.tag': {
+            'Meta': {'object_name': 'Tag'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_for_main_display': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '128'}),
+            'statuses': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'old_tags'", 'symmetrical': 'False', 'to': u"orm['facebook_feeds.Facebook_Status']"})
+        },
+        u'facebook_feeds.user_token': {
+            'Meta': {'object_name': 'User_Token'},
+            'date_of_creation': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2014, 11, 24, 0, 0)'}),
+            'date_of_expiration': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2015, 1, 23, 0, 0)'}),
+            'feeds': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'tokens'", 'symmetrical': 'False', 'to': u"orm['facebook_feeds.Facebook_Feed']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'token': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '256'}),
+            'user_id': ('django.db.models.fields.TextField', [], {'unique': 'True'})
+        }
+    }
+
+    complete_apps = ['facebook_feeds']


### PR DESCRIPTION
now relies on patterns from the DB that can include the feed name for (hopefully) better accuracy and manageability
