### PR TITLE
Fixed details block appears without content

### DIFF
--- a/kikar_hamedina/core/templates/core/billboards_list.html
+++ b/kikar_hamedina/core/templates/core/billboards_list.html
@@ -6,9 +6,6 @@
     {% trans 'Billboards' %}
 {% endblock %}
 
-{% block context-header %}
-{% endblock context-header %}
-
 {% block main_content %}
 
     {% load humanize %}

--- a/kikar_hamedina/core/templates/core/custom.html
+++ b/kikar_hamedina/core/templates/core/custom.html
@@ -22,7 +22,8 @@
     {#    {% endif %}#}
 {% endblock %}
 
-{% block details %}
+{% block context-header %}
+<div class="container well" id="details-container">
     <div class="h4">
         מספר תוצאות: {{ number_of_results }}
     </div>
@@ -38,4 +39,5 @@
 תיאור וקישור:
         <a href="{{ saved_query.path }}"> {{ saved_query.description }}</a>
     </div>
+</div>
 {% endblock %}

--- a/kikar_hamedina/core/templates/core/customs_list.html
+++ b/kikar_hamedina/core/templates/core/customs_list.html
@@ -8,8 +8,8 @@
     שליפות מוגדרות מראש
 {% endblock %}
 
-{% block details %}
-
+{% block context-header %}
+<div class="container well" id="details-container">
     {% if requested_user %}
         <h4>
             משתמש:
@@ -19,7 +19,7 @@
     <h4>
         מס' שאילתות: {{ object_list.count }}
     </h4>
-
+</div>
 {% endblock %}
 
 {% block main_content %}

--- a/kikar_hamedina/core/templates/core/facebook_status_detail.html
+++ b/kikar_hamedina/core/templates/core/facebook_status_detail.html
@@ -9,9 +9,6 @@
 {% block h1 %}
 {% endblock %}
 
-{% block context-header %}
-{% endblock %}
-
 {% block main_content %}
 
     <div class="container" style="max-width: 800px" id="single-status-container">

--- a/kikar_hamedina/core/templates/core/member.html
+++ b/kikar_hamedina/core/templates/core/member.html
@@ -8,7 +8,8 @@
     <i class="fa fa-user"></i> {{ object.name }}
 {% endblock %}
 
-{% block details %}
+{% block context-header %}
+<div class="container well" id="details-container">
     {% with object.facebook_persona.get_main_feed as feed %}
         {% load humanize %}
         {% load core_extras %}
@@ -56,6 +57,7 @@
         {% endif %}
 
     {% endwith %}
+</div>
 {% endblock %}
 
 {% block noposts %}
@@ -81,4 +83,3 @@
 {% block scripts %}
     <script type="text/javascript" src="{{ STATIC_URL }}js/updateInsightsForMember.js"></script>
 {% endblock %}
-

--- a/kikar_hamedina/core/templates/core/party.html
+++ b/kikar_hamedina/core/templates/core/party.html
@@ -7,7 +7,8 @@
     <i class="fa fa-group"></i> {{ object.name }}
 {% endblock %}
 
-{% block details %}
+{% block context-header %}
+<div class="container well" id="details-container">
     <h4>{% trans 'Number of Facebook Pages for Party' %}: {{ object.current_members.count }}
     </h4>
     <p id="insights" style="display: none">
@@ -19,6 +20,7 @@
         <span id="ins_n_week">-</span> {% trans 'Statuses' %},
         <span id="ins_mean_likes_week">-</span> {% trans 'Likes on average' %}
     </p>
+</div>    
 {% endblock %}
 
 {% block sidebar %}

--- a/kikar_hamedina/core/templates/core/rss_widget_page.html
+++ b/kikar_hamedina/core/templates/core/rss_widget_page.html
@@ -7,14 +7,6 @@
     {% trans 'RSS Updates' %}
 {% endblock %}
 
-
-{% block context-header %}
-    {#    <div class="container well" id="details-container">#}
-    {#        {% block details %}#}
-    {##}
-    {#        {% endblock %}#}
-    {#    </div>#}
-{% endblock %}
 {% block main_content %}
     {% load humanize %}
     {% load core_extras %}

--- a/kikar_hamedina/core/templates/core/search.html
+++ b/kikar_hamedina/core/templates/core/search.html
@@ -22,7 +22,8 @@
 
 {% endblock %}
 
-{% block details %}
+{% block context-header %}
+<div class="container well" id="details-container">
     <div class="h4">
         {% blocktrans %}Number of Results{% endblocktrans %} : {{ number_of_results }}
     </div>
@@ -36,4 +37,5 @@
         </p>
         {% endif %}
     </h4>
+</div>
 {% endblock %}

--- a/kikar_hamedina/core/templates/core/tag.html
+++ b/kikar_hamedina/core/templates/core/tag.html
@@ -12,8 +12,10 @@
 
 {% endblock %}
 
-{% block details %}
+{% block context-header %}
+<div class="container well" id="details-container">
     <h4>{% trans 'Total' %}: {{ object_list.count }}</h4>
+</div>
 {% endblock %}
 
 {% block sidebar %}

--- a/kikar_hamedina/templates/layouts/generic-template.html
+++ b/kikar_hamedina/templates/layouts/generic-template.html
@@ -265,11 +265,6 @@
             </div>
         </div>
         {% block context-header %}
-            <div class="container well" id="details-container">
-                {% block details %}
-
-                {% endblock %}
-            </div>
         {% endblock %}
 
         {% block main_content %}


### PR DESCRIPTION
To do that I removed the 'details' block from `generic-template.html` and inserted the `.well` div container directly to the templates where the block appeared.

In order to insert details the `context-header` block should be used now. 