### PR TITLE
Remove not needed print

### DIFF
--- a/kikar_hamedina/core/templatetags/core_extras.py
+++ b/kikar_hamedina/core/templatetags/core_extras.py
@@ -56,5 +56,4 @@ def path_to_params(path):
 
 @register.filter(name='language_clean_uri')
 def language_clean_uri(uri):
-    print uri
     return uri.split('/en')[-1].split('/ar')[-1].split('/he')[-1]


### PR DESCRIPTION
This print causes an I/O Error 32 once in a blue moon. Thanks to bots and having permalinks on the site this happens more often than we would want. 

As this print is not needed, removing it is the right decision